### PR TITLE
fix: enlarge modal to match cozy-ui mobile break point

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -35,10 +35,10 @@ body {
     position: absolute;
     top: 50%;
     height: 10600px;
-    width: 10700px;
+    width: 10800px;
     left: 50%;
     margin-top: -5300px;
-    margin-left: -5350px;
+    margin-left: -5400px;
     z-index: 10000;
   }
 }


### PR DESCRIPTION
La modale qui charge l'intent avait une largeur de 700px, notre breakpoint mobile étant à 768px, le contenu passait systématiquement en mode mobile, même sur desktop.

J'ai ouvert une issue sur cozy-ui pour éclaircir le sujet dans la doc https://github.com/cozy/cozy-ui/issues/205